### PR TITLE
Creates React component nodes without children if node tag is a void …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Creates React component nodes without children if node tag is a void element

--- a/src/JsonmlToReact.js
+++ b/src/JsonmlToReact.js
@@ -4,7 +4,8 @@ import isFunction from 'lodash.isfunction';
 
 import {
   reactConverters,
-  toStyleObject
+  toStyleObject,
+  voidElementTags
 } from './utils';
 
 
@@ -47,8 +48,6 @@ export default class JsonmlToReact {
     }
 
     const tag = JsonML.getTagName(node);
-    const children = JsonML.getChildren(node) || [];
-
     const converter = this.converters[tag];
     const result = isFunction(converter) ? converter(attrs, data) : {};
 
@@ -57,6 +56,13 @@ export default class JsonmlToReact {
 
     // reassign key in case `converter` removed it
     props.key = props.key || index;
+
+    // If it's a void element, don't create children
+    if (voidElementTags[type]) {
+      return React.createElement(tag, props);
+    }
+
+    const children = JsonML.getChildren(node) || [];
 
     return React.createElement(type, props, children.map((child, index) => this._visit(child, index, data)));
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -141,6 +141,31 @@ export const reactHTMLTags = [
 
 
 /**
+ * List of "void element" tags
+ * lifted from React source
+ * https://github.com/facebook/react/blob/6a659606415d4853026df6e6d525274fdc7d35ea/src/renderers/dom/shared/ReactDOMComponent.js#L443
+ */
+export const voidElementTags = {
+  area: true,
+  base: true,
+  br: true,
+  col: true,
+  embed: true,
+  hr: true,
+  img: true,
+  input: true,
+  keygen: true,
+  link: true,
+  meta: true,
+  param: true,
+  source: true,
+  track: true,
+  wbr: true,
+  menuitem: true
+};
+
+
+/**
  * Object with converters for the React tags
  */
 export const reactConverters = reactHTMLTags.reduce((acc, type) => {

--- a/test/src/JsonmlToReact.spec.js
+++ b/test/src/JsonmlToReact.spec.js
@@ -44,6 +44,15 @@ describe('JsonmlToReact class', function () {
       expect(result).to.be.equal(leaf);
     });
 
+    it('returns a component without children if void element', () => {
+      let node = ['hr'];
+      let result = jsonmlToReact._visit(node);
+
+      expect(result.type).to.be.a('string');
+      expect(result.type).to.be.equal('hr');
+      expect(result.children).to.not.exist;
+    });
+
     it('returns component with `type` as string, equals to node tag if node is HTML tag', () => {
       let node = ['a'];
       let result = jsonmlToReact._visit(node);


### PR DESCRIPTION
At some point a version of React (15?) began raising hard errors when attempting to nest children / inner HTML within "void element".  Previously it was a warning.  See: https://github.com/facebook/react/pull/3372/commits/aca4ccda357824243fd1125d5c64a83028c30be8

This is an attempt to avoid that.  Note that there is no warning / error raised if the user of `JsonmlToReact` does attempt to do so; the rest of the tree will silently not be converted to React elements.

Should we add a warning of some sort, or do we think this is okay to ship?

@mvattuone @pgoldrbx @diffcunha 