### PR TITLE
React.createElement takes children as args, not as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+* React components' children are no longer wrapped in an array,
+  resulting in fewer `<!--react-text-->` blocks when stringified
+
 ### 0.1.0 (2016-08-26)
 
 * Creates React component nodes without children if node tag is a void element

--- a/src/JsonmlToReact.js
+++ b/src/JsonmlToReact.js
@@ -64,7 +64,7 @@ export default class JsonmlToReact {
 
     const children = JsonML.getChildren(node) || [];
 
-    return React.createElement(type, props, children.map((child, index) => this._visit(child, index, data)));
+    return React.createElement(type, props, ...children.map((child, index) => this._visit(child, index, data)));
   }
 
   /**

--- a/test/src/JsonmlToReact.spec.js
+++ b/test/src/JsonmlToReact.spec.js
@@ -149,4 +149,19 @@ describe('JsonmlToReact class', function () {
       jsonmlToReact._visit.restore();
     });
   });
+
+  describe('React.createElement', () => {
+    it('should call children as arguments', () => {
+      let spy = sinon.spy(ReactMock, 'createElement');
+
+      let node = ['p', {}, 'i am a text node'];
+
+      jsonmlToReact.convert(node);
+
+      expect(spy.calledWith('p', { key: 0 }, 'i am a text node')).to.be.true;
+
+      ReactMock.createElement.restore();
+    });
+  });
+
 });


### PR DESCRIPTION
React.createElement's signature is `React.createElement(
  type,
  [props],
  [...children]
)`, but jsonmltoreact called it with `React.createElement(
  type,
  [props],
  [children]
)`.

This resulted in every element being wrapped in `<!-- react-text: XXX -->` comment tags, unnecessarily polluting the source.