### PR TITLE
Avoid mutating the inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepublish": "npm run build",
     "prepush": "npm test",
     "pretest": "npm run lint",
-    "test": "NODE_ENV=test nyc mocha"
+    "test": "NODE_ENV=test nyc mocha",
+    "tdd": "NODE_ENV=test nyc mocha --watch"
   },
   "repository": {
     "type": "git",
@@ -41,6 +42,7 @@
     "husky": "^0.11.4",
     "mocha": "^2.4.5",
     "nyc": "^6.4.4",
+    "react": "^16.2.0",
     "sinon": "^1.17.4"
   },
   "nyc": {

--- a/src/JsonmlToReact.js
+++ b/src/JsonmlToReact.js
@@ -36,26 +36,19 @@ export default class JsonmlToReact {
       return node;
     }
 
-    let attrs = Object.assign({ key: index }, JsonML.getAttributes(node));
-
-    if (attrs.class) {
-      attrs.className = attrs.class;
-      attrs.class = undefined;
-    }
-
-    if (attrs.style) {
-      attrs.style = toStyleObject(attrs.style);
-    }
-
+    const rawAttrs = Object.assign({}, JsonML.getAttributes(node));
     const tag = JsonML.getTagName(node);
     const converter = this.converters[tag];
-    const result = isFunction(converter) ? converter(attrs, data) : {};
+    const result = isFunction(converter) ? converter(rawAttrs, data) : {};
 
     const type = result.type || tag;
-    const props = result.props || attrs;
-
-    // reassign key in case `converter` removed it
-    props.key = props.key || index;
+    const resultProps = result.props || rawAttrs || {};
+    const props = Object.assign({}, resultProps, {
+      className: resultProps.className || resultProps.class,
+      class: undefined,
+      key: index,
+      style: rawAttrs.style && toStyleObject(rawAttrs.style)
+    });
 
     // If it's a void element, don't create children
     if (voidElementTags[type]) {

--- a/test/src/JsonmlToReact.spec.js
+++ b/test/src/JsonmlToReact.spec.js
@@ -158,7 +158,12 @@ describe('JsonmlToReact class', function () {
 
       jsonmlToReact.convert(node);
 
-      expect(spy.calledWith('p', { key: 0 }, 'i am a text node')).to.be.true;
+      expect(spy.calledWith('p', {
+        className: undefined,
+        class: undefined,
+        key: 0,
+        style: undefined
+      }, 'i am a text node')).to.be.true;
 
       ReactMock.createElement.restore();
     });


### PR DESCRIPTION
## Observed Bug

The visitor was mutating nested props. Specifically, a `key` property was
being added to on Multitenant app. If the state was made immutable, this
would throw an exception.

## Solution

Copy the results of the converter, add the `key` to that copy.