### PR TITLE
Allow React 16 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash.isfunction": "^3.0.8"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",


### PR DESCRIPTION
We're currently using this under React 16 in github.com/CondeNast/aviator-multi-tenant without problems. I'd just like to stop getting the following warning from npm:

```
npm WARN @condenast/jsonmltoreact@1.0.0 requires a peer of react@^0.14.0 || ^15.0.0 but none is installed. You must install peer dependencies yourself.
```