### PR TITLE
Remove class prop by proper filtering, and add test.

### DIFF
--- a/src/JsonmlToReact.js
+++ b/src/JsonmlToReact.js
@@ -3,6 +3,7 @@ import JsonML from 'jsonml.js/lib/utils';
 import isFunction from 'lodash.isfunction';
 
 import {
+  filter,
   reactConverters,
   toStyleObject,
   voidElementTags
@@ -43,9 +44,8 @@ export default class JsonmlToReact {
 
     const type = result.type || tag;
     const resultProps = result.props || rawAttrs || {};
-    const props = Object.assign({}, resultProps, {
+    const props = Object.assign({}, filter(resultProps, key => key !== 'class'), {
       className: resultProps.className || resultProps.class,
-      class: undefined,
       key: index,
       style: rawAttrs.style && toStyleObject(rawAttrs.style)
     });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,20 @@
 import camelCase from 'lodash.camelcase';
 
+/**
+ * Returns a copy of an object, with specific keys omitted
+ *
+ * @param {Object} obj - Source object
+ * @param {Function} filterFn - function to check if a key/val pair should be retained
+ * @returns {Object} a new object omitting keys
+ */
+export function filter(obj, filterFn) {
+  return Object.keys(obj).reduce((acc, key) => {
+    if (filterFn(key, obj[key])) {
+      acc[key] = obj[key];
+    }
+    return acc;
+  }, {});
+}
 
 /**
  * React HTML tags

--- a/test/src/JsonmlToReact.spec.js
+++ b/test/src/JsonmlToReact.spec.js
@@ -177,7 +177,6 @@ describe('JsonmlToReact class', function () {
       let node = ['p', {}, 'i am a text node'];
       const expectedAttributes = {
         className: undefined,
-        class: undefined,
         key: 0,
         style: undefined
       };

--- a/test/src/utils.spec.js
+++ b/test/src/utils.spec.js
@@ -1,21 +1,27 @@
 import { expect } from 'chai';
 
 import {
+  filter,
   reactHTMLTags,
   reactConverters,
   toStyleObject
 } from '../../src/utils';
 
+describe('filter', function () {
+  it('should filter matching keys', function () {
+    const foo = { bar: 1, foo: 2, class: 3 };
+    expect(filter(foo, key => key !== 'class')).to.deep.equal({ bar: 1, foo: 2 });
+  });
+});
 
-describe('reactConverters array', () => {
+describe('reactConverters array', function () {
   it('is a object with all HTML tags as keys and a function as value', function () {
     expect(reactConverters).to.have.all.keys(reactHTMLTags);
   });
 });
 
-
-describe('toStyleObject function', () => {
-  it('returns class object parsed from the CSS style string', () => {
+describe('toStyleObject function', function () {
+  it('returns class object parsed from the CSS style string', function () {
     let css = 'display: block; color: #fff;';
     let result = toStyleObject(css);
 


### PR DESCRIPTION
The existing code for this retained a key/value pair `class: undefined` in each React node, which in dev mode led to this constantly appearing in the console:

![screen shot 2018-06-18 at 10 32 24 am](https://user-images.githubusercontent.com/248669/41546791-91fd9906-72ec-11e8-82c7-fbf0116cbd7a.png)

In this PR I'm changing the `class: undefined` overwrite into a filter, to elide the prop entirely and silence these warning noises.