### PR TITLE
Switch to Conde Nast fork of jsonml.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jsonml.js": "^0.1.0",
+    "@condenast/jsonml.js": "^1.0.0",
     "lodash.camelcase": "^4.1.1",
     "lodash.isfunction": "^3.0.8"
   },

--- a/src/JsonmlToReact.js
+++ b/src/JsonmlToReact.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import JsonML from 'jsonml.js/lib/utils';
+import JsonML from '@condenast/jsonml.js/lib/utils';
 import isFunction from 'lodash.isfunction';
 
 import {


### PR DESCRIPTION
I forked this project into our org a while back because it wasn't really being maintained and we rely on it. Since then, I put time into getting test coverage on a lot of the code,  fixing a few issues, and expanding documentation. Let's switch to the better, internally-supported library!

https://github.com/CondeNast/jsonml.js

**All changes**
(most are dev/docs/linting/tests)
https://github.com/benjycui/jsonml.js/compare/master...CondeNast:master

Fixes applied in our fork:
- [fix: use html.isRaw method when appending child Markup instances](https://github.com/benjycui/jsonml.js/commit/9d0c9e21cb41def5b2b710bd587e9a7054483a20)
- [fix: prevent mutation if fragment param when appending](https://github.com/benjycui/jsonml.js/commit/29046f8e896d61a3c1a0a51b8f2b4be4f445f07e)