### PR TITLE
Update @condenast/jsonml.js to version 1.0.1 to fix es5-compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Update @condenast/jsonml.js to version 1.0.1 to fix es5-compatibility
+
 ### 2.1.0 (2018-11-08)
 
 * Switch to Conde Nast fork of jsonml.js (#16)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@condenast/jsonml.js": "^1.0.0",
+    "@condenast/jsonml.js": "^1.0.1",
     "lodash.camelcase": "^4.1.1",
     "lodash.isfunction": "^3.0.8"
   },

--- a/src/JsonmlToReact.js
+++ b/src/JsonmlToReact.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import JsonML from '@condenast/jsonml.js/lib/utils';
+import JsonML from '@condenast/jsonml.js/dist/utils';
 import isFunction from 'lodash.isfunction';
 
 import {


### PR DESCRIPTION
- Updated to maintain es5-compatibility. (see https://github.com/CondeNast/jsonml.js/pull/18)
- Addressed a breaking change for `lib` => `dist` path.
  NOTE: I don't consider the internal file-paths within a module to be part of the supported API unless documented by a package. In this case, it [_is_ documented](https://github.com/CondeNast/jsonml.js#usage) so should be addressed.