### PR TITLE
chore: Update babel packages to @babel scope and v7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["@babel/env"],
   "env": {
     "test": {
       "plugins": ["rewire"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+#### Chores
+* Update babel packages to @babel scope and v7
+
 ### 2.1.1 (2018-11-09)
 
 * Update @condenast/jsonml.js to version 1.0.1 to fix es5-compatibility

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "build": "npm run build:js",
     "build:js": "./node_modules/.bin/babel ./src --out-dir ./lib",
-    "coverage": "nyc --reporter=lcov --require babel-core/register mocha ${TEST_FILES:-test/src/index.spec.js}",
+    "coverage": "nyc --reporter=lcov --require @babel/register mocha ${TEST_FILES:-test/src/index.spec.js}",
     "lint": "eslint --ext .js -c .eslintrc .",
     "prebuild": "rm -rf lib",
     "precommit": "npm run lint",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "prepush": "npm test",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test nyc mocha",
@@ -30,13 +30,14 @@
     "react": "^16.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.8.0",
-    "babel-core": "^6.8.0",
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.8.4",
+    "@babel/preset-env": "^7.8.4",
+    "@babel/register": "^7.8.3",
+    "@babel/template": "^7.8.3",
+    "@babel/types": "^7.8.3",
     "babel-eslint": "^6.0.4",
-    "babel-plugin-rewire": "^1.0.0-rc-3",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-template": "^6.8.0",
-    "babel-types": "^6.8.1",
+    "babel-plugin-rewire": "^1.2.0",
     "chai": "^3.5.0",
     "eslint": "^2.10.1",
     "husky": "^0.11.4",
@@ -47,7 +48,7 @@
   },
   "nyc": {
     "require": [
-      "babel-core/register"
+      "@babel/register"
     ]
   }
 }


### PR DESCRIPTION
- Update babel packages to `@babel` scope
- Update to latest (7.x)
- Update `prepublish` to `prepublishOnly` to avoid running build during install