### PR TITLE
chore: update husky to v4 and configure hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "coverage": "nyc --reporter=lcov --require @babel/register mocha ${TEST_FILES:-test/src/index.spec.js}",
     "lint": "eslint --ext .js -c .eslintrc .",
     "prebuild": "rm -rf lib",
-    "precommit": "npm run lint",
     "prepublishOnly": "npm run build",
-    "prepush": "npm test",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test nyc mocha",
     "tdd": "NODE_ENV=test nyc mocha --watch --break"
@@ -40,11 +38,17 @@
     "babel-plugin-rewire": "^1.2.0",
     "chai": "^3.5.0",
     "eslint": "^2.10.1",
-    "husky": "^0.11.4",
+    "husky": "^4.2.3",
     "mocha": "^2.4.5",
     "nyc": "^6.4.4",
     "react": "^16.2.0",
     "sinon": "^9.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint",
+      "pre-push": "npm test"
+    }
   },
   "nyc": {
     "require": [


### PR DESCRIPTION
`husky@1.0.0` introduced breaking changes where hooks had to be configured separately from the package scripts. This has been implemented along with updating to the latest version (4.x)