### PR TITLE
chore: Update nyc to v15 and fix generated coverage reports

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+# COVERALLS_REPO_TOKEN should be set in Travis-CI
+repo_token: ${COVERALLS_REPO_TOKEN}

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,14 @@
+{
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "include": [
+    "src/**/*.js"
+  ],
+  "require": [
+    "@babel/register"
+  ],
+  "sourceMap": true,
+  "instrument": true
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/CondeNast/jsonmltoreact.svg?branch=master)](https://travis-ci.org/CondeNast/jsonmltoreact)
 [![Code Climate](https://codeclimate.com/github/diffcunha/jsonmltoreact/badges/gpa.svg)](https://codeclimate.com/github/diffcunha/jsonmltoreact)
-[![Test Coverage](https://codeclimate.com/github/diffcunha/jsonmltoreact/badges/coverage.svg)](https://codeclimate.com/github/diffcunha/jsonmltoreact/coverage)
+[![Coverage Status](https://coveralls.io/repos/github/CondeNast/jsonmltoreact/badge.svg?branch=master)](https://coveralls.io/github/CondeNast/jsonmltoreact?branch=master)
 
 # jsonmltoreact
 JsonML to React converter

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "^2.10.1",
     "husky": "^4.2.3",
     "mocha": "^2.4.5",
-    "nyc": "^6.4.4",
+    "nyc": "^15.0.0",
     "react": "^16.2.0",
     "sinon": "^9.0.0"
   },
@@ -49,10 +49,5 @@
       "pre-commit": "npm run lint",
       "pre-push": "npm test"
     }
-  },
-  "nyc": {
-    "require": [
-      "@babel/register"
-    ]
   }
 }


### PR DESCRIPTION
- move configuration to `.nycrc`
- generate `coverage/lcov.info`
- properly instrument source using babel
- Fixed coveralls reporting https://coveralls.io/github/CondeNast/jsonmltoreact